### PR TITLE
Fall back when capture_output is not supported

### DIFF
--- a/tornettools/generate_tor.py
+++ b/tornettools/generate_tor.py
@@ -15,8 +15,14 @@ from tornettools.util import load_json_data
 
 def __generate_authority_keys(torgencertexe, datadir, torrc, pwpath):
     cmd = "{} --create-identity-key -m 24 --passphrase-fd 0".format(torgencertexe)
-    with open(pwpath, 'r') as pwin:
-        proc = subprocess.run(shlex.split(cmd), stdin=pwin, capture_output=True)
+
+    # capture_output is only added in python 3.7 or later
+    try:
+        with open(pwpath, 'r') as pwin:
+            proc = subprocess.run(shlex.split(cmd), stdin=pwin, capture_output=True)
+    except:
+        with open(pwpath, 'r') as pwin:
+            proc = subprocess.run(shlex.split(cmd), stdin=pwin)
 
     if proc.returncode != 0:
         err = proc.stderr.decode('utf-8')

--- a/tornettools/tornettools
+++ b/tornettools/tornettools
@@ -81,7 +81,7 @@ DESC_PLOT = """
 Visualizes various performance metrics that were extracted and
 stored with the parse command by producing graphical plots.
 
-This command should be used after running plot.
+This command should be used after running parse.
 """
 
 HELP_ARCHIVE = """

--- a/tornettools/tornettools
+++ b/tornettools/tornettools
@@ -304,7 +304,7 @@ def main():
             if this option is unspecified, then we will copy the atlas from the tmodel_git_path repo
             into the config directory that we generate.
             (A compressed version of the file is normally available at
-            'tmodel_git_path/data/shadow/network/atlas.201801.shadow113.graphml.xml.xz'.)""",
+            'tmodel_git_path/data/shadow/network/atlas_v201801.shadow_v2.gml.xz'.)""",
         metavar="PATH", type=__type_str_file_path_in,
         action="store", dest="atlas_path",
         default=None)


### PR DESCRIPTION
I think `capture_output` is not supported before python 3.7; this patch makes it work on Cent OS 7.