### PR TITLE
Use integer division when calculating 'parallelism'

### DIFF
--- a/tornettools/tornettools
+++ b/tornettools/tornettools
@@ -360,7 +360,7 @@ def main():
         help="""The argument string to pass to Shadow when running the simulation.""",
         type=str,
         action="store", dest="shadow_args",
-        default="--parallelism={} --seed=666".format(cpu_count()/2))
+        default="--parallelism={} --seed=666".format(cpu_count()//2))
 
     simulate_parser.add_argument('-c', '--compress',
         help="""Compress output with lzma.""",


### PR DESCRIPTION
Can't have a decimal in the parallelism option.