### PR TITLE
More flexibility for running simulations

### DIFF
--- a/tornettools/archive.py
+++ b/tornettools/archive.py
@@ -19,7 +19,8 @@ def run(args):
     logging.info("Compressing consensus.")
     __xz_parallel(args, "consensus")
     logging.info("Compressing shadow config.")
-    __xz_parallel(args, "shadow.config.yaml")
+    __xz_parallel(args, "shadow.config.xml") # for shadow v1.15.x
+    __xz_parallel(args, "shadow.config.yaml") # for shadow v2.x.x
     logging.info("Compressing dstat log.")
     __xz_parallel(args, "dstat.log")
     logging.info("Compressing free log.")

--- a/tornettools/simulate.py
+++ b/tornettools/simulate.py
@@ -34,16 +34,15 @@ def run(args):
 def __run_shadow(args):
     shadow_exe_path = args.shadowexe
     if shadow_exe_path == None:
-        logging.warning("Cannot find shadow in your PATH. Do you have shadow installed (e.g., in ~/.shadow/bin)? Did you update your PATH?")
+        logging.warning("Cannot find shadow in your PATH. Do you have shadow installed? Did you update your PATH?")
         logging.warning("Unable to run simulation without shadow.")
         return None
 
     cmd_prefix = "/usr/bin/chrt -f 1 " if args.use_realtime else ""
-    args_suffix = " --template-directory=shadow.data.template" if '--template-directory' not in args.shadow_args else ""
 
     shadow_args = args.shadow_args
     with open_writeable_file(f"{args.prefix}/shadow.log", compress=args.do_compress) as outf:
-        shadow_cmd = cmdsplit(f"{cmd_prefix}{shadow_exe_path} {shadow_args}{args_suffix} shadow.config.yaml")
+        shadow_cmd = cmdsplit(f"{cmd_prefix}{shadow_exe_path} {shadow_args}")
         comproc = subprocess.run(shadow_cmd, cwd=args.prefix, stdout=outf)
 
     return comproc

--- a/tornettools/tornettools
+++ b/tornettools/tornettools
@@ -350,17 +350,25 @@ def main():
     simulate_parser.add_argument('-s', '--shadow',
         help="""Path to a compiled 'shadow' executable to use when running the simulation.""",
         metavar="PATH", type=__type_str_file_path_in,
-        action="store", dest="shadowexe",
+        action="store", dest="shadow_exe",
         default=which("shadow"))
 
     # We set parallelism to cpu_count / 2 since we observed that this can run up to 3 times
     # faster on machines with Intel hyperthreading enabled.
     # Non-hyperthreaded CPUs may perform better with cpu_count instead.
     simulate_parser.add_argument('-a', '--args',
-        help="""The argument string to pass to Shadow when running the simulation.""",
+        help="""The Shadow options to use when running the simulation.""",
         type=str,
         action="store", dest="shadow_args",
-        default="--parallelism={} --seed=666 --template-directory=shadow.data.template shadow.config.yaml".format(cpu_count()//2))
+        default="--parallelism={} --seed=666 --template-directory=shadow.data.template".format(cpu_count()//2))
+
+    # This option allows us to swap the filename with shadow.config.xml in Shadow v1.15.x.
+    # Once we no longer care about supporting Shadow v1.15.x, we could remove this option.
+    simulate_parser.add_argument('-f', '--filename',
+        help="""The Shadow config filename to use when running the simulation.""",
+        type=str,
+        action="store", dest="shadow_config",
+        default="shadow.config.yaml")
 
     simulate_parser.add_argument('-c', '--compress',
         help="""Compress log output from Shadow using lzma.""",

--- a/tornettools/tornettools
+++ b/tornettools/tornettools
@@ -348,7 +348,7 @@ def main():
         type=__type_str_dir_path_in)
 
     simulate_parser.add_argument('-s', '--shadow',
-        help="""Path to a compile 'shadow' executable to use when running the simulation.""",
+        help="""Path to a compiled 'shadow' executable to use when running the simulation.""",
         metavar="PATH", type=__type_str_file_path_in,
         action="store", dest="shadowexe",
         default=which("shadow"))
@@ -360,10 +360,10 @@ def main():
         help="""The argument string to pass to Shadow when running the simulation.""",
         type=str,
         action="store", dest="shadow_args",
-        default="--parallelism={} --seed=666".format(cpu_count()//2))
+        default="--parallelism={} --seed=666 --template-directory=shadow.data.template shadow.config.yaml".format(cpu_count()//2))
 
     simulate_parser.add_argument('-c', '--compress',
-        help="""Compress output with lzma.""",
+        help="""Compress log output from Shadow using lzma.""",
         action="store_true", dest="do_compress",
         default=False)
 


### PR DESCRIPTION
This allows us to fully customize the argument string that we pass
to shadow when running a simulation. This is particularly useful
when running simulations with v1.15.x, since the args that were
hard-coded here before were not available in v1.15.0.

Also, we now try to compress both yaml and xml config files if
they exist.