### PR TITLE
Support new graph and config formats used by shadow

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,17 +101,19 @@ Here is a bibtex entry for latex users:
         consensuses-2020-11 \
         server-descriptors-2020-11 \
         userstats-relay-country.csv \
+        tmodel-ccs2018.github.io \
         --onionperf_data_path onionperf-2020-11 \
         --bandwidth_data_path bandwidth-2020-11.csv \
         --geoip_path tor/src/config/geoip
 
 ### now we can used the staged files to generate many times
 
-For example, use '--network_scale 0.01' to generate a private Tor network at '1%' the scale of public Tor:
+For example, use `--network_scale 0.01` to generate a private Tor network at '1%' the scale of public Tor:
 
     tornettools generate \
         relayinfo_staging_2020-11-01--2020-11-30.json \
         userinfo_staging_2020-11-01--2020-11-30.json \
+        networkinfo_staging.gml \
         tmodel-ccs2018.github.io \
         --network_scale 0.01 \
         --prefix tornet-0.01

--- a/tornettools/generate.py
+++ b/tornettools/generate.py
@@ -4,11 +4,15 @@ import json
 import yaml
 import logging
 import shlex
+import shutil
+import random
+from ipaddress import IPv4Address
+
+import networkx as nx
 
 from tornettools.generate_defaults import *
 from tornettools.generate_tgen import *
 from tornettools.generate_tor import *
-from tornettools.util import copy_and_extract_file
 
 def run(args):
     if args.torexe == None:
@@ -21,6 +25,21 @@ def run(args):
         return
 
     logging.info(f"Generating network using tor and tor-gencert at {args.torexe} and {args.torgencertexe}")
+
+    os.mkdir("{}/{}".format(args.prefix, CONFIG_DIRNAME))
+
+    # only copy the compressed atlas file if the user did not give us a custom path
+    if args.atlas_path is None:
+        logging.info("Copying atlas topology file (use the '-a/--atlas' option to disable)")
+        topology_src_path = "{}/data/shadow/network/{}.xz".format(args.tmodel_git_path, TMODEL_TOPOLOGY_FILENAME)
+        topology_dst_path = "{}/{}/{}.xz".format(args.prefix, CONFIG_DIRNAME, TMODEL_TOPOLOGY_FILENAME)
+        shutil.copy2(topology_src_path, topology_dst_path)
+        args.atlas_path = topology_dst_path
+
+    # read the staged network info graph, which contains all of the atlas graph nodes
+    logging.info(f"Reading staged network info {args.network_info_path}")
+    network = nx.readwrite.gml.read_gml(args.network_info_path, label='id')
+    logging.info("Finished reading staged network info")
 
     # get the set of relays we will create in shadow
     logging.info("Sampling Tor relays now")
@@ -50,14 +69,7 @@ def run(args):
     generate_tgen_config(args, tgen_clients, tgen_servers)
 
     logging.info("Constructing Shadow config YAML file")
-    __generate_shadow_config(args, authorities, relays, tgen_servers, perf_clients, tgen_clients)
-
-    # only copy the atlas file if the user did not tell us where it has the atlas stored
-    if args.atlas_path is None:
-        logging.info("Copying atlas topology file (use the '-a/--atlas' option to disable)")
-        topology_src_path = "{}/data/shadow/network/{}.xz".format(args.tmodel_git_path, TMODEL_TOPOLOGY_FILENAME)
-        topology_dst_path = "{}/{}/{}.xz".format(args.prefix, CONFIG_DIRNAME, TMODEL_TOPOLOGY_FILENAME)
-        copy_and_extract_file(topology_src_path, topology_dst_path)
+    __generate_shadow_config(args, network, authorities, relays, tgen_servers, perf_clients, tgen_clients)
 
 def __relay_to_torrc_default_include(relay):
     if "exitguard" in relay['nickname']:
@@ -78,8 +90,7 @@ def __relay_host_torrc_defaults(relay):
 
     return {'includes': includes, 'bandwidth_rate': rate, 'bandwidth_burst': burst}
 
-
-def __generate_shadow_config(args, authorities, relays, tgen_servers, perf_clients, tgen_clients):
+def __generate_shadow_config(args, network, authorities, relays, tgen_servers, perf_clients, tgen_clients):
     # create the YAML for the shadow.config.yaml file
 
     config = {}
@@ -95,28 +106,26 @@ def __generate_shadow_config(args, authorities, relays, tgen_servers, perf_clien
 
     config["network"]["graph"] = {}
     config["network"]["graph"]["type"] = "gml"
-
-    if args.atlas_path is None:
-        config["network"]["graph"]["path"] = "{}/{}".format(CONFIG_DIRNAME, TMODEL_TOPOLOGY_FILENAME)
-    else:
-        config["network"]["graph"]["path"] = str(args.atlas_path)
+    config["network"]["graph"]["file"] = {}
+    config["network"]["graph"]["file"]["path"] = str(args.atlas_path)
+    config["network"]["graph"]["file"]["compression"] = "xz"
 
     for (fp, authority) in sorted(authorities.items(), key=lambda kv: kv[1]['nickname']):
-        config["hosts"].update(__tor_relay(args, authority, fp, is_authority=True))
+        config["hosts"].update(__tor_relay(args, network, authority, fp, is_authority=True))
 
     for pos in ['ge', 'e', 'g', 'm']:
         # use reverse to sort each class from fastest to slowest when assigning the id counter
         for (fp, relay) in sorted(relays[pos].items(), key=lambda kv: kv[1]['weight'], reverse=True):
-            config["hosts"].update(__tor_relay(args, relay, fp, is_authority=False))
+            config["hosts"].update(__tor_relay(args, network, relay, fp, is_authority=False))
 
     for server in tgen_servers:
-        config["hosts"].update(__server(args, server))
+        config["hosts"].update(__server(args, network, server))
 
     for client in perf_clients:
-        config["hosts"].update(__perfclient(args, client))
+        config["hosts"].update(__perfclient(args, network, client))
 
     for client in tgen_clients:
-        config["hosts"].update(__markovclient(args, client))
+        config["hosts"].update(__markovclient(args, network, client))
 
     with open("{}/{}".format(args.prefix, SHADOW_CONFIG_FILENAME), 'w') as configfile:
         yaml.dump(config, configfile, sort_keys=False)
@@ -133,14 +142,72 @@ def __get_scaled_tgen_server_bandwidth_kbit(args):
     scaled_bw = scaled_client_bw * n_clients_per_server
     return scaled_bw
 
-def __server(args, server):
+def __filter_nodes(network, ip_address_hint, country_code_hint):
+    # networkx stores the node 'id' separately, so take the node id from the tuple and combine it
+    # with the other node properties
+    all_nodes = [{'id': node_id, **node} for (node_id, node) in network.nodes(data=True)]
+
+    if ip_address_hint is not None and not ip_address_hint.is_global:
+        # ignore the hint if the IP address is not global
+        logging.debug(f"Ignoring non-global address {ip_address_hint}")
+        ip_address_hint = None
+
+    if country_code_hint is not None:
+        # normalize the country code
+        country_code_hint = country_code_hint.casefold()
+
+    # are there any nodes with the same ip address?
+    ip_match_found = any('ip_address' in node and IPv4Address(node['ip_address']) == ip_address_hint for node in all_nodes)
+
+    if ip_match_found:
+        # get all nodes with exact IP matches, regardless of the country code
+        candidate_nodes = [node for node in all_nodes if 'ip_address' in node and IPv4Address(node['ip_address']) == ip_address_hint]
+    else:
+        # get all nodes with the same country code
+        candidate_nodes = [node for node in all_nodes if 'country_code' in node and node['country_code'].casefold() == country_code_hint]
+
+        # if no node had the same country code, use all nodes
+        if len(candidate_nodes) == 0:
+            candidate_nodes = [node for node in all_nodes]
+
+        any_ip_found = any('ip_address' in node for node in candidate_nodes)
+
+        # if a node has an IP address and we were given an IP hint, perform longest prefix matching
+        if any_ip_found and ip_address_hint is not None:
+            # exclude nodes without an IP address
+            candidate_nodes = [node for node in candidate_nodes if 'ip_address' in node]
+
+            # function to compute the prefix match between two IPv4 addresses
+            # the 32-bit mask is required since python uses signed integers
+            #   (see https://stackoverflow.com/questions/210629/python-unsigned-32-bit-bitwise-arithmetic/210740)
+            def compute_prefix_match(ip_1, ip_2): return ~(int(ip_1)^int(ip_2)) & 0xffffffff
+
+            # get the prefix match for each node
+            prefix_matches = [(node, compute_prefix_match(IPv4Address(node['ip_address']), ip_address_hint)) for node in candidate_nodes]
+
+            # get the longest prefix match
+            max_prefix_match = max(prefix_matches, key=lambda x: x[1])[1]
+
+            # get the nodes with the longest prefix match
+            candidate_nodes = [node for (node, prefix_match) in prefix_matches if prefix_match == max_prefix_match]
+
+            # given the 'compute_prefix_match' function above, these nodes should all have the same IP address
+            assert len(set([IPv4Address(node['ip_address']) for node in candidate_nodes])) == 1
+
+    return candidate_nodes
+
+def __server(args, network, server):
     # Make sure we have enough bandwidth for the expected number of clients
     scaled_bw_kbit = __get_scaled_tgen_server_bandwidth_kbit(args)
     host_bw_kbit = max(BW_1GBIT_KBIT, scaled_bw_kbit)
 
+    # filter the network graph nodes by their country, and choose one node
+    country_code_hint = server.get('country_code')
+    chosen_node = random.choice(__filter_nodes(network, None, country_code_hint))
+
+    # add the host element and attributes
     host = {}
-    host["options"] = {}
-    host["options"]["country_code_hint"] = str(server['country_code']).upper()
+    host['network_node_id'] = chosen_node['id']
 
     host["bandwidth_up"] = "{} kilobit".format(host_bw_kbit)
     host["bandwidth_down"] = "{} kilobit".format(host_bw_kbit)
@@ -157,13 +224,13 @@ def __server(args, server):
 
     return {server['name']: host}
 
-def __perfclient(args, client):
-    return __tgen_client(args, client['name'], client['country_code'], \
+def __perfclient(args, network, client):
+    return __tgen_client(args, network, client['name'], client['country_code'], \
         get_host_rel_conf_path(TGENRC_PERFCLIENT_FILENAME))
 
-def __markovclient(args, client):
+def __markovclient(args, network, client):
     # these should be relative paths
-    return __tgen_client(args, client['name'], client['country_code'], \
+    return __tgen_client(args, network, client['name'], client['country_code'], \
         TGENRC_MARKOVCLIENT_FILENAME)
 
 def __format_tor_args(name):
@@ -175,14 +242,18 @@ def __format_tor_args(name):
     ]
     return ' '.join(args)
 
-def __tgen_client(args, name, country, tgenrc_fname):
+def __tgen_client(args, network, name, country, tgenrc_fname):
     # Make sure we have enough bandwidth for the simulated number of users
     scaled_bw_kbit = __get_scaled_tgen_client_bandwidth_kbit(args)
     host_bw_kbit = max(BW_1GBIT_KBIT, scaled_bw_kbit)
 
+    # filter the network graph nodes by their country, and choose one node
+    country_code_hint = country
+    chosen_node = random.choice(__filter_nodes(network, None, country_code_hint))
+
+    # add the host element and attributes
     host = {}
-    host["options"] = {}
-    host["options"]["country_code_hint"] = str(country).upper()
+    host['network_node_id'] = chosen_node['id']
 
     host["bandwidth_up"] = "{} kilobit".format(host_bw_kbit)
     host["bandwidth_down"] = "{} kilobit".format(host_bw_kbit)
@@ -209,7 +280,7 @@ def __tgen_client(args, name, country, tgenrc_fname):
 
     return {name: host}
 
-def __tor_relay(args, relay, orig_fp, is_authority=False):
+def __tor_relay(args, network, relay, orig_fp, is_authority=False):
     # prepare items for the host element
     kbits = 8 * int(round(int(relay['bandwidth_capacity']) / 1000.0))
 
@@ -217,11 +288,17 @@ def __tor_relay(args, relay, orig_fp, is_authority=False):
     with open("{}/{}/fingerprint-public-tor".format(hosts_prefix, relay['nickname']), 'w') as outf:
         outf.write(f"{orig_fp}\n")
 
+    # filter the network graph nodes by their IP address and country, and choose one node
+    ip_address_hint = IPv4Address(relay['address']) if 'address' in relay else None
+    country_code_hint = relay.get('country_code')
+    chosen_node = random.choice(__filter_nodes(network, ip_address_hint, country_code_hint))
+
     # add the host element and attributes
     host = {}
-    host["options"] = {}
-    host["options"]["ip_address_hint"] = relay['address']
-    host["options"]["country_code_hint"] = str(relay['country_code']).upper()
+    host['network_node_id'] = chosen_node['id']
+
+    if 'address' in relay:
+        host["ip_addr"] = relay['address']
 
     host["bandwidth_down"] = "{} kilobit".format(kbits)
     host["bandwidth_up"] = "{} kilobit".format(kbits)

--- a/tornettools/tornettools
+++ b/tornettools/tornettools
@@ -176,6 +176,11 @@ def main():
         help="Path to a Tor user stats file (https://metrics.torproject.org/userstats-relay-country.csv)",
         type=__type_str_file_path_in)
 
+    stage_parser.add_argument("tmodel_git_path",
+        help="Path to a local directory that contains a git clone of the repo: \
+            'https://github.com/tmodel-ccs2018/tmodel-ccs2018.github.io.git'",
+        type=__type_str_dir_path_in)
+
     stage_parser.add_argument('-o', '--onionperf_data_path',
         help="Path to a directory of onionperf performance data",
         type=__type_str_dir_path_in,
@@ -230,6 +235,10 @@ def main():
 
     generate_parser.add_argument("user_info_path",
         help="Path to a user-info-staging.json file produced with the 'stage' command",
+        type=__type_str_file_path_in)
+
+    generate_parser.add_argument("network_info_path",
+        help="Path to a network-info-staging.json file produced with the 'stage' command",
         type=__type_str_file_path_in)
 
     generate_parser.add_argument("tmodel_git_path",

--- a/tornettools/util.py
+++ b/tornettools/util.py
@@ -48,15 +48,6 @@ def load_json_data(infile_path):
         data = json.load(infile)
     return data
 
-def copy_and_extract_file(src, dst):
-    shutil.copy2(src, dst)
-
-    xz_cmd = "xz -d {}".format(dst)
-    completed_proc = subprocess.run(shlex.split(xz_cmd), stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-    if completed_proc.returncode != 0:
-        logging.critical("Error extracting file {} using command {}".format(dst, xz_cmd))
-    assert completed_proc.returncode == 0
-
 def find_matching_files_in_dir(search_dir, filename):
     logging.info(f"Searching for files with name {filename} in directory tree at {search_dir}")
     found = []


### PR DESCRIPTION
Support the new shadow graph and configuration formats. We now assign hosts directly to graph nodes rather than using hints like "country_code_hint" and "ip_address_hint", so we now need to read and use the network graph.

@robgjansen Let me know if you'd like me to rename any of the options or filenames. Also I think I replicated the host assignment logic to be the same as it is in shadow, but make sure it aligns with how you expect it to run,