### PR TITLE
Plot goodput in mega-bps instead of mibi-bps

### DIFF
--- a/tornettools/parse_tgen.py
+++ b/tornettools/parse_tgen.py
@@ -218,9 +218,9 @@ def __get_client_goodput(data, startts, stopts, start_bytes, end_bytes):
                 end_time = tgen_stream_seconds_at_bytes(stream, end_bytes)
                 if start_time is not None and end_time is not None and end_time > start_time:
                     bps = (end_bytes - start_bytes)  * 8.0 / (end_time - start_time)
-                    # TODO: this probably ought to be Mbps (i.e. divide by
-                    # 10**6, not 2**20).  Left as Mibps for now for
-                    # compatibility with old plot data.
+                    # We ultimately want to graph Mbps, but for compatibility
+                    # with old data sets, we record Mibi-bps. This is
+                    # converted to Mbps in the `plot` step.
                     Mibps = bps / 2**20
                     goodput.append(Mibps)
 

--- a/tornettools/plot.py
+++ b/tornettools/plot.py
@@ -240,7 +240,9 @@ def __plot_client_goodput(args, torperf_dbs, tornet_dbs):
 
     # cache the corresponding data in the 'data' keyword for __plot_cdf_figure
     for tornet_db in tornet_dbs:
-        tornet_db['data'] = tornet_db['dataset']
+        # For compatibility with legacy parsed data, the output of the parse
+        # step is in *mebi* bits per second.  Convert to *mega* here.
+        tornet_db['data'] = [[x*2**20/1e6 for x in ds] for ds in tornet_db['dataset']]
     for torperf_db in torperf_dbs:
         # Covert to Mbps
         client_gput = [t/1e6 for t in torperf_db['dataset']["client_goodput"]]
@@ -257,7 +259,9 @@ def __plot_client_goodput_5MiB(args, torperf_dbs, tornet_dbs):
 
     # cache the corresponding data in the 'data' keyword for __plot_cdf_figure
     for tornet_db in tornet_dbs:
-        tornet_db['data'] = tornet_db['dataset']
+        # For compatibility with legacy parsed data, the output of the parse
+        # step is in *mebi* bits per second.  Convert to *mega* here.
+        tornet_db['data'] = [[x*2**20/1e6 for x in ds] for ds in tornet_db['dataset']]
     for torperf_db in torperf_dbs:
         # Covert to Mbps
         client_gput = [t/1e6 for t in torperf_db['dataset']["client_goodput_5MiB"]]


### PR DESCRIPTION
The data generated in the `tornettools parse` step is in Mibi-bps. The conventional unit, and the label on the graphs, is Mega-bps (aka Mbps or Mbit/s).

Changing the unit that `tornettools parse` records would lead to some subtle issues when replotting old data sets. e.g. when plotting a new run against an old baseline, the new run would be in Mbps, but the old run would still be in Mibi-bps.

Instead, this fix converts at plot time. We can see in the [parse_and_plot graphs](https://github.com/shadow/tornettools/actions/runs/1427164339) that when plotting old and new data together, this fixes the units on *both* lines, causing them to overlap perfectly.

To see the difference this PR makes, we can visually compare against a graph from a [previous run](https://github.com/shadow/tornettools/actions/runs/1427156232):

![image](https://user-images.githubusercontent.com/179146/140570356-88c3282b-9095-4490-b3e2-d653aea581eb.png)

As expected, the lines are shifted slightly (~5%) along the x-axis.