### PR TITLE
Filter zero-bandwidth tor nodes

### DIFF
--- a/tornettools/generate_tor.py
+++ b/tornettools/generate_tor.py
@@ -413,7 +413,8 @@ def __sample_relays(relays, sample_size):
     for fp in all_fingerprints:
         freq = float(relays[fp]['running_frequency'])
         weight = float(relays[fp]['weight'])
-        if freq < RUN_FREQ_THRESH or weight == 0.0:
+        bandwidth_capacity = float(relays[fp]['bandwidth_capacity'])
+        if freq < RUN_FREQ_THRESH or weight == 0.0 or bandwidth_capacity == 0.0:
             freq = 0.0
         run_freqs.append(freq)
     # normalize


### PR DESCRIPTION
Fixes #49 

In the staging step, it's possible to end up with tor relays with 0 bandwidth but non-zero weight.

Since we already have filtering in the `generate` step but not the `stage` step, I added this additional filter in the `generate` step with the rest.