### PR TITLE
Copy template directory option from command line to configuration file

### DIFF
--- a/tornettools/generate.py
+++ b/tornettools/generate.py
@@ -111,6 +111,9 @@ def __generate_shadow_config(args, network, authorities, relays, tgen_servers, p
     config["general"]["bootstrap_end_time"] = BOOTSTRAP_LENGTH_SECONDS # disable bandwidth limits and packet loss for first 5 minutes
     config["general"]["stop_time"] = SIMULATION_LENGTH_SECONDS # stop after 1 hour of simulated time
 
+    # for compatability with old tornettools sims, this is also set as a default shadow argument in the cli
+    config["general"]["template_directory"] = "shadow.data.template"
+
     # the atlas topology is complete, so we can use only direct edges
     config["network"]["use_shortest_path"] = False
 

--- a/tornettools/tornettools
+++ b/tornettools/tornettools
@@ -377,6 +377,10 @@ def main():
         help="""The Shadow options to use when running the simulation.""",
         type=str,
         action="store", dest="shadow_args",
+        # The template directory is also set to the same value in the configuration file.
+        # It is set here as well so that old shadow simulations that don't have it set in
+        # the configuration file will still run correctly. This option can be removed from
+        # these default shadow options in the future.
         default="--parallelism={} --seed=666 --template-directory=shadow.data.template".format(cpu_count()//2))
 
     # This option allows us to swap the filename with shadow.config.xml in Shadow v1.15.x.


### PR DESCRIPTION
I think this makes more sense to have in the configuration file. I'm leaving it in the command line for now so that older shadow sims will still work.

It can still be overridden using the `--args` option, but I don't see a reason why you'd ever need to change it.