### PR TITLE
parse_and_plot: fix no-op diff

### DIFF
--- a/.github/workflows/parse_and_plot.yml
+++ b/.github/workflows/parse_and_plot.yml
@@ -69,10 +69,11 @@ jobs:
       # golden data in `.github/workflows/parse_and_plot_output` can be updated
       # using the actual output from this workflow's artifacts.
       - name: Diff
-        run: for f in .github/workflows/parse_and_plot_output/tornet.plot.data/*.json;
+        run: |
+          for f in .github/workflows/parse_and_plot_output/tornet.plot.data/*.json
           do 
             echo "Diffing $f"
-            diff $f parse_and_plot_output/tornet.plot.data/$(basename $f);
+            diff $f parse_and_plot_output/tornet.plot.data/$(basename $f)
           done
 
       - name: Plot


### PR DESCRIPTION
Commit https://github.com/shadow/tornettools/commit/e3306eaa38904e38ec1969c6827de8522e3b6a53 added an `echo`
statement without a semicolon to a yaml "folded" string. i.e. the
newline literals in the strings get removed, so the next line in the
source became extra arguments to `echo`.

This changes the string from a "folded" string to a "literal" string,
which preserves newlines.