### PR TITLE
Don't escape %

### DIFF
--- a/tornettools/plot.py
+++ b/tornettools/plot.py
@@ -260,7 +260,7 @@ def __plot_transfer_error_rates(args, circuittype, torperf_dbs, tornet_dbs, erro
     dbs_to_plot = torperf_dbs + tornet_dbs
 
     __plot_cdf_figure(args, dbs_to_plot, f"transfer_error_rates_{error_key}.{circuittype}",
-                      xlabel=f"{circuittype} Transfer Error Rate (\\%): Type={error_key}")
+                      xlabel=f"{circuittype} Transfer Error Rate (%): Type={error_key}")
 
 def __plot_client_goodput(args, circuittype, torperf_dbs, tornet_dbs):
     if circuittype == 'onionservice':


### PR DESCRIPTION
This doesn't appear to be necessary. Some of us have vague memories of latex errors without it, but I haven't been able to reproduce. I also tried including one of the generated figures in a latex paper, and that worked as well.

Let's get rid of it for now, and if we have a problem again revert and leave a comment about why it's escaped :)