### PR TITLE
Stop using `import *`

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,16 @@
+[flake8]
+ignore =
+  # expected 2 blank lines, found 1.
+  E302,
+  # line too long.
+  E501,
+  # at least two spaces before inline comment.
+  E261,
+  # block comment should start with '# '
+  E265,
+  # multiple statements on one line
+  E704,
+  # ambiguous variable name
+  E741,
+  # line break after binary operator
+  W504,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,10 +62,4 @@ jobs:
           flake8
 
       - name: Run flake8
-        # Ignores:
-        # * E302: E302 expected 2 blank lines, found 1.
-        # * E501 line too long.
-        # * E261 at least two spaces before inline comment.
-        # * E265 block comment should start with '# '
-        # * E741 ambiguous variable name
-        run: flake8 --extend-ignore=E302,E501,E261,E265,E741 tornettools
+        run: flake8 tornettools

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,4 @@ jobs:
         # * E261 at least two spaces before inline comment.
         # * E265 block comment should start with '# '
         # * E741 ambiguous variable name
-        # * F403 'from X import *' used; unable to detect undefined names
-        # * F405 may be undefined, or defined from star imports
-        run: flake8 --extend-ignore=E302,E501,E261,E265,E741,F403,F405 tornettools
+        run: flake8 --extend-ignore=E302,E501,E261,E265,E741 tornettools

--- a/tornettools/generate.py
+++ b/tornettools/generate.py
@@ -8,9 +8,23 @@ import base64
 
 import networkx as nx
 
-from tornettools.generate_defaults import *
-from tornettools.generate_tgen import *
-from tornettools.generate_tor import *
+from tornettools.generate_tgen import generate_tgen_config, get_clients, get_servers
+from tornettools.generate_defaults import (BOOTSTRAP_LENGTH_SECONDS, BW_1GBIT_KBIT, BW_1MBIT_KBIT,
+                                           BW_RATE_MIN, CONFIG_DIRNAME, SHADOW_CONFIG_FILENAME,
+                                           SHADOW_HOSTS_PATH, SHADOW_INSTALL_PREFIX,
+                                           SHADOW_TEMPLATE_PATH, SIMULATION_LENGTH_SECONDS,
+                                           TGENRC_MARKOVCLIENT_FILENAME, TGENRC_PERFCLIENT_EXIT_FILENAME,
+                                           TGENRC_PERFCLIENT_HS_FILENAME, TGENRC_SERVER_FILENAME,
+                                           TGEN_ONIONSERVICE_PORT, TGEN_SERVER_PORT,
+                                           TMODEL_TOPOLOGY_FILENAME, TORRC_CLIENT_FILENAME,
+                                           TORRC_CLIENT_MARKOV_FILENAME, TORRC_CLIENT_PERF_FILENAME,
+                                           TORRC_DEFAULTS_HOST_FILENAME, TORRC_HOST_FILENAME,
+                                           TORRC_ONIONSERVICE_FILENAME, TORRC_RELAY_AUTHORITY_FILENAME,
+                                           TORRC_RELAY_EXITGUARD_FILENAME, TORRC_RELAY_EXITONLY_FILENAME,
+                                           TORRC_RELAY_FILENAME, TORRC_RELAY_GUARDONLY_FILENAME,
+                                           TORRC_RELAY_OTHER_FILENAME, TOR_CONTROL_PORT,
+                                           TOR_ONIONSERVICE_DIR, get_host_rel_conf_path)
+from tornettools.generate_tor import generate_tor_config, generate_tor_keys, get_relays
 
 def run(args):
     if args.torexe is None:

--- a/tornettools/generate_tgen.py
+++ b/tornettools/generate_tgen.py
@@ -11,7 +11,15 @@ from random import randrange
 
 from networkx import DiGraph, write_graphml
 
-from tornettools.generate_defaults import *
+from tornettools.generate_defaults import (CONFIG_DIRNAME, ONIONPERF_COUNTRY_CODES,
+                                           PRIVCOUNT_PERIODS_PER_DAY, SHADOW_HOSTS_PATH,
+                                           SHADOW_TEMPLATE_PATH, TGENRC_FLOWMODEL_FILENAME_FMT,
+                                           TGENRC_MARKOVCLIENT_FILENAME,
+                                           TGENRC_PERFCLIENT_EXIT_FILENAME,
+                                           TGENRC_PERFCLIENT_HS_FILENAME, TGENRC_SERVER_FILENAME,
+                                           TGEN_CLIENT_MIN_COUNT, TGEN_SERVER_PORT,
+                                           TMODEL_PACKETMODEL_FILENAME, TMODEL_STREAMMODEL_FILENAME,
+                                           TOR_SOCKS_PORT, get_host_rel_conf_path)
 from tornettools.util import load_json_data
 
 def __round_or_ceil(x):

--- a/tornettools/generate_tor.py
+++ b/tornettools/generate_tor.py
@@ -9,7 +9,21 @@ from multiprocessing import Pool, cpu_count
 from numpy import array_split
 from numpy.random import choice, uniform
 
-from tornettools.generate_defaults import *
+from tornettools.generate_defaults import (BW_1GBIT_BYTES, BW_AUTHORITY_NAME, CONFIG_DIRNAME,
+                                           DIRAUTH_COUNTRY_CODES, RESOLV_FILENAME, RUN_FREQ_THRESH,
+                                           SHADOW_HOSTS_PATH, SHADOW_TEMPLATE_PATH,
+                                           TGEN_ONIONSERVICE_PORT, TGEN_SERVER_PORT,
+                                           TORRC_CLIENT_FILENAME, TORRC_CLIENT_MARKOV_FILENAME,
+                                           TORRC_CLIENT_PERF_FILENAME, TORRC_COMMON_FILENAME,
+                                           TORRC_DEFAULTS_HOST_FILENAME, TORRC_HOST_FILENAME,
+                                           TORRC_ONIONSERVICE_FILENAME,
+                                           TORRC_RELAY_AUTHORITY_FILENAME,
+                                           TORRC_RELAY_EXITGUARD_FILENAME,
+                                           TORRC_RELAY_EXITONLY_FILENAME, TORRC_RELAY_FILENAME,
+                                           TORRC_RELAY_GUARDONLY_FILENAME,
+                                           TORRC_RELAY_OTHER_FILENAME, TOR_CONTROL_PORT,
+                                           TOR_DIR_PORT, TOR_GUARD_MIN_CONSBW, TOR_ONIONSERVICE_DIR,
+                                           TOR_OR_PORT, TOR_SOCKS_PORT, get_host_rel_conf_path)
 from tornettools.util import load_json_data
 
 def __generate_authority_keys(torgencertexe, datadir, torrc, pwpath):

--- a/tornettools/plot.py
+++ b/tornettools/plot.py
@@ -9,7 +9,8 @@ from matplotlib.backends.backend_pdf import PdfPages
 
 from tornettools.util import load_json_data, find_matching_files_in_dir
 
-from tornettools.plot_common import *
+from tornettools.plot_common import (DEFAULT_COLORS, DEFAULT_LINESTYLES, draw_cdf, draw_cdf_ci,
+                                     draw_line, draw_line_ci, quantile, set_plot_options)
 from tornettools.plot_tgen import plot_tgen
 from tornettools.plot_oniontrace import plot_oniontrace
 


### PR DESCRIPTION
Notably this allows us to enable rule [F403](https://www.flake8rules.com/rules/F403.html) in flake8, which detects usage of undefined names.

Also moved the flake8 configuration to a `.flake8` config file, so that it's used when running locally as well without having to copy the rule set to the command line.