### PR TITLE
Enable ProtocolWarnings

### DIFF
--- a/tornettools/generate_tor.py
+++ b/tornettools/generate_tor.py
@@ -267,6 +267,7 @@ def __generate_torrc_common(conf_path, authorities, geoip_path):
     torrc_file.write('GeoIPFile {}\n'.format(geoip_path or ''))
     # Never load the geoipv6 file, since we don't support ipv6.
     torrc_file.write('GeoIPV6File\n')
+    torrc_file.write('ProtocolWarnings 1\n')
 
     torrc_file.close()
 


### PR DESCRIPTION
Normally violations of the protocol are logged only at info level, since
they're both common and unactionable in the real network.

In a tornettools simulation with what should be good versions of tor,
we probably want to know about these.