### PR TITLE
Migrate from flake8 w503 to w504

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -12,5 +12,5 @@ ignore =
   E704,
   # ambiguous variable name
   E741,
-  # line break after binary operator
-  W504,
+  # line break before binary operator
+  W503,

--- a/tornettools/generate_tgen.py
+++ b/tornettools/generate_tgen.py
@@ -394,9 +394,9 @@ def __get_perf_clients(args, n_exit_users, n_hs_users):
     perf_clients = []
 
     n_perf = args.torperf_num_onion_service + args.torperf_num_exit
-    if (args.torperf_num_onion_service != args.torperf_num_exit and
-            args.torperf_num_onion_service != 0 and
-            args.torperf_num_exit != 0):
+    if (args.torperf_num_onion_service != args.torperf_num_exit
+            and args.torperf_num_onion_service != 0
+            and args.torperf_num_exit != 0):
         logging.warning("Unequal number of perf nodes. Is this what you meant? "
                         f"torperf_num_onion_service={args.torperf_num_onion_service} "
                         f"torperf_num_exit={args.torperf_num_exit}")

--- a/tornettools/generate_tor.py
+++ b/tornettools/generate_tor.py
@@ -664,10 +664,10 @@ def __check_weights_errors(Wgg, Wgd, Wmg, Wme, Wmd, Wee, Wed,
         return (a - b) <= margin if (a - b) >= 0 else (b - a) <= margin
 
     def check_range(a, b, c, d, e, f, g, mx):
-        return (a >= 0 and a <= mx and b >= 0 and b <= mx and
-                c >= 0 and c <= mx and d >= 0 and d <= mx and
-                e >= 0 and e <= mx and f >= 0 and f <= mx and
-                g >= 0 and g <= mx)
+        return (a >= 0 and a <= mx and b >= 0 and b <= mx
+                and c >= 0 and c <= mx and d >= 0 and d <= mx
+                and e >= 0 and e <= mx and f >= 0 and f <= mx
+                and g >= 0 and g <= mx)
 
         # Wed + Wmd + Wgd == weightscale
     if (not check_eq(Wed + Wmd + Wgd, weightscale, margin)):
@@ -760,8 +760,7 @@ def __recompute_bwweights(G, M, E, D, T):
 
                 check = __check_weights_errors(Wgg, Wgd, Wmg, Wme, Wmd,
                                                Wee, Wed, weightscale, G, M, E, D, T, 10, True)
-            if (check != bww_errors.NO_ERROR and check !=
-                    bww_errors.BALANCE_MID_ERROR):
+            if (check != bww_errors.NO_ERROR and check != bww_errors.BALANCE_MID_ERROR):
                 raise ValueError(
                     'ERROR: {0}  Wgd={1}, Wed={2}, Wmd={3}, Wee={4},\
                         Wme={5}, Wmg={6}, Wgg={7}'.format(bww_errors[check],


### PR DESCRIPTION
w503 (line break should be before binary operator) has been obsoleted in
favor of w504 (line break should be *after* binary operator). See
https://www.flake8rules.com/rules/W503.html