### PR TITLE
This adds 10MiB downloads hack to tornettools

### DIFF
--- a/tornettools/generate_tgen.py
+++ b/tornettools/generate_tgen.py
@@ -78,6 +78,7 @@ def __generate_tgenrc_perfclient(server_peers, path):
     G.add_node("stream_50k", sendsize="1000 bytes", recvsize="50 KiB", stallout="0 seconds", timeout="15 seconds")
     G.add_node("stream_1m", sendsize="1000 bytes", recvsize="1 MiB", stallout="0 seconds", timeout="60 seconds")
     G.add_node("stream_5m", sendsize="1000 bytes", recvsize="5 MiB", stallout="0 seconds", timeout="120 seconds")
+    G.add_node("stream_10m", sendsize="1000 bytes", recvsize="10 MiB", stallout="0 seconds", timeout="240 seconds")
 
     G.add_edge("start", "pause")
 
@@ -89,6 +90,7 @@ def __generate_tgenrc_perfclient(server_peers, path):
     G.add_edge("pause", "stream_50k", weight="12.0")
     G.add_edge("pause", "stream_1m", weight="2.0")
     G.add_edge("pause", "stream_5m", weight="1.0")
+    G.add_edge("pause", "stream_10m", weight="1.0")
 
     write_graphml(G, path)
 

--- a/tornettools/parse_onionperf.py
+++ b/tornettools/parse_onionperf.py
@@ -11,8 +11,8 @@ from tornettools.util import dump_json_data, open_readable_file, aka_int, tgen_s
 
 def run(args):
     db = {"circuit_rtt": [], "client_goodput": [], "client_goodput_5MiB": [],
-          "circuit_build_times": [], "download_times": {}, "daily_counts": {},
-          "relay_goodput": {}}
+          "client_goodput_10MiB": [], "circuit_build_times": [],
+          "download_times": {}, "daily_counts": {}, "relay_goodput": {}}
 
     if args.bandwidth_data_path is not None:
         logging.info(f"Parsing bandwidth data stored in '{args.bandwidth_data_path}'")
@@ -159,6 +159,11 @@ def __handle_stream(db, stream, day):
         if goodput is not None:
             db['client_goodput_5MiB'].append(goodput)
 
+        goodput = __goodput_bps(
+            stream, aka_int(9437184, 9 * 2**20), aka_int(10485760, 10 * 2**20))
+        if goodput is not None:
+            db['client_goodput_10MiB'].append(goodput)
+
     elif lb > 0 and cmd > 0:
         __store_transfer_time(db, transfer_size_target, ttlb)
 
@@ -187,5 +192,7 @@ def __get_timeout_limit(num_bytes):
         return 60.0
     elif num_bytes == 5242880:
         return 120.0
+    elif num_bytes == 10485760:
+        return 240.0
     else:
         return 3600.0

--- a/tornettools/parse_tgen.py
+++ b/tornettools/parse_tgen.py
@@ -55,6 +55,7 @@ def extract_tgen_plot_data(args):
         __extract_error_rate(args, data, circuittype, startts, stopts)
         __extract_client_goodput(args, data, circuittype, startts, stopts)
         __extract_client_goodput_5MiB(args, data, circuittype, startts, stopts)
+        __extract_client_goodput_10MiB(args, data, circuittype, startts, stopts)
 
 def __extract_round_trip_time(args, data, circuittype, startts, stopts):
     rtt = __get_round_trip_time(data, circuittype, startts, stopts)
@@ -97,6 +98,17 @@ def __extract_client_goodput_5MiB(args, data, circuittype, startts, stopts):
         aka_int(4194304, 4 * 2**20),
         aka_int(5242880, 5 * 2**20))
     outpath = f"{args.prefix}/tornet.plot.data/perfclient_goodput_5MiB.{circuittype}.json"
+    dump_json_data(client_goodput, outpath, compress=False)
+
+def __extract_client_goodput_10MiB(args, data, circuittype, startts, stopts):
+    # goodput of the 10th Mebibyte. metrics.torproject uses this as of ~ April 2022.
+    # https://gitlab.torproject.org/jnewsome/sponsor-61-sims/-/issues/15
+    # https://metrics.torproject.org/reproducible-metrics.html#performance
+    client_goodput = __get_client_goodput(
+        data, circuittype, startts, stopts,
+        aka_int(9437184, 9 * 2**20),
+        aka_int(10485760, 10 * 2**20))
+    outpath = f"{args.prefix}/tornet.plot.data/perfclient_goodput_10MiB.{circuittype}.json"
     dump_json_data(client_goodput, outpath, compress=False)
 
 def __get_download_time(data, circuittype, startts, stopts, bytekey):


### PR DESCRIPTION
This adds the possibility to test 10MiB downloads with tornettools. See https://gitlab.torproject.org/jnewsome/sponsor-61-sims/-/issues/15

For the time being this is a test that is going to be used for the S61 simulation work within Tor. As mentioned in the gitlab issue we might think to add different download sizes to https://github.com/shadow/tornettools/blob/main/tornettools/generate_defaults.py later on.