### PR TITLE
Log error message if shadow sim failed

### DIFF
--- a/tornettools/simulate.py
+++ b/tornettools/simulate.py
@@ -32,6 +32,10 @@ def run(args):
         return 1
 
     logging.info(f"Done simulating; shadow returned code '{comproc.returncode}'")
+
+    if comproc.returncode != 0:
+        logging.error("Shadow simulation did not complete successfully")
+
     return comproc.returncode
 
 def __run_shadow(args):


### PR DESCRIPTION
If the simulation failed, it should be shown more prominently.