### PR TITLE
Generate certificates valid during shadow's emulated time

### DIFF
--- a/.github/workflows/run_all_steps.yml
+++ b/.github/workflows/run_all_steps.yml
@@ -260,6 +260,14 @@ jobs:
       - name: Archive
         run: tornettools archive tornet
 
+      - name: Upload tornet
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: tornet
+          path: tornet
+          retention-days: 5
+
       # Use this artifact to update .github/workflow/parse_and_plot_input when
       # necessary - e.g. when the output of the tgen or oniontrace parsers
       # changes in some significant way.

--- a/.github/workflows/run_all_steps.yml
+++ b/.github/workflows/run_all_steps.yml
@@ -197,6 +197,8 @@ jobs:
 
       - name: Generate
         run: |
+          # Needed for fake certificate timestamps
+          sudo apt-get install -y faketime
           # Simulate a very small network to keep this test fast.
           NETWORK_SCALE=0.0001
           # Likewise use a relatively small number of perf nodes, but still

--- a/README.md
+++ b/README.md
@@ -91,6 +91,13 @@ Here is a bibtex entry for latex users:
     make -j$(nproc)
     cd ..
 
+### install additional executables used by tornettools
+
+`tornettools` also uses the `faketime`, `dstat`, `free`, and `xz` command-line
+tools. On Ubuntu these can be installed with:
+
+    sudo apt-get install faketime dstat procps xz-utils
+
 ### in order to generate, we need a tor and tor-gencert binaries (to generate relay keys)
 
     export PATH=${PATH}:`pwd`/tor/src/core/or:`pwd`/tor/src/app:`pwd`/tor/src/tools

--- a/tornettools/generate_defaults.py
+++ b/tornettools/generate_defaults.py
@@ -68,6 +68,11 @@ TMODEL_STREAMMODEL_FILENAME = "tgen.tor-streammodel-ccs2018.graphml"
 TMODEL_PACKETMODEL_FILENAME = "tgen.tor-packetmodel-ccs2018.graphml"
 TMODEL_TOPOLOGY_FILENAME = "atlas_v201801.shadow_v2.gml"
 
+# Timestamp passed to faketime(1) when generating certificates. Should be < 1
+# year before simulation start (which is currently hard-coded in shadow to
+# 2000-01-01).
+CERT_FAKETIMESTAMP = "1999-12-01"
+
 def get_host_rel_conf_path(rc_filename, rc_subdirname=None):
     if rc_subdirname is None:
         return f"../../../{CONFIG_DIRNAME}/{rc_filename}"


### PR DESCRIPTION
tor currently doesn't care if certificates were generated in the future,
at least for testing networks, but arti does. Since it's relatively easy
to generate certificates that are valid during the simulation's emulated
time, this seems preferable vs adding a test-only path in arti.