### PR TITLE
Don't include RAM usage after the sim end time in realtime plots

### DIFF
--- a/tornettools/plot.py
+++ b/tornettools/plot.py
@@ -101,9 +101,14 @@ def __plot_memory_usage_real_time(args, tornet_dbs):
         for i, d in enumerate(tornet_db['dataset']):
             if 'ram' not in d or 'gib_used_per_minute' not in d['ram']:
                 continue
+            if 'run_time' not in d or 'seconds' not in d['run_time']:
+                continue
             ramd = d['ram']['gib_used_per_minute']
             for real_minute in ramd:
                 s = int(real_minute) * 60.0 # to seconds
+                # don't include ram usage after the sim end time
+                if s > d['run_time']['seconds']:
+                    continue
                 xy.setdefault(s, []).append(ramd[real_minute])
         tornet_db['data'] = xy
 


### PR DESCRIPTION
This is a small improvement to the realtime RAM plots to avoid large confidence intervals due to one simulation dropping to ~0 ram usage when other sims in the dataset were still running.

The RAM usage plots should maybe use a different method for calculating confidence intervals since it doesn't make sense that we'd lose confidence in the upper bound when one simulation ends, but this PR should hopefully be an improvement on the existing method.

Before:

![ram_realtime](https://user-images.githubusercontent.com/3708797/170385481-57ac2570-251b-403a-8a16-a2070a126d85.png)

After:

![ram_realtime](https://user-images.githubusercontent.com/3708797/170385510-f4325333-6ed1-4536-9e49-7bea607b67dc.png)
