### PR TITLE
Add comment to readme about '--editable' pip flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,10 @@ Here is a bibtex entry for latex users:
     python3 -m venv toolsenv
     source toolsenv/bin/activate
     pip install -r requirements.txt
-    pip install -I .
+    # if you plan to make changes to tornettools, you can add the '--editable' pip install flag
+    # to avoid the need to re-run 'pip install' after every modification:
+    # https://pip.pypa.io/en/stable/topics/local-project-installs/#editable-installs
+    pip install --ignore-installed .
 
 ### read the help menus
 


### PR DESCRIPTION
The `--editable` flag is probably always what people who want to make changes to tornettools want to use, and I always need to look up what the flag is each time I install tornettools, so it's probably helpful to add this to the readme. I also expanded the `-I` flag to `--ignore-installed` since it's a non-obvious flag, and I also have to always look that one up to see what it's doing.