### PR TITLE
run_all_steps: Unconditionally checkout shadow to get build deps

### DIFF
--- a/.github/workflows/run_all_steps.yml
+++ b/.github/workflows/run_all_steps.yml
@@ -80,7 +80,6 @@ jobs:
           key: shadow-${{ env.SHADOW_COMMIT }}-${{ env.CACHE_VERSION }}
 
       - name: Checkout shadow
-        if: steps.restore-shadow-build-cache.outputs.cache-hit != 'true'
         uses: actions/checkout@v2
         with:
           repository: shadow/shadow


### PR DESCRIPTION
Without this change, if there's a shadow build cache hit, we'll fail to access shadow's dependency installation scripts in the next step.