### PR TITLE
Update the heartbeat log search string

### DIFF
--- a/tornettools/parse_rusage.py
+++ b/tornettools/parse_rusage.py
@@ -65,7 +65,8 @@ def __parse_shadow_rusage(args):
         return False
 
     rusage = {}
-    heartbeat = re.compile("_manager_heartbeat")
+    # shadow's C code didn't capitalize "process", shadow's rust code does
+    heartbeat = re.compile("[Pp]rocess resource usage at simtime")
     with open_readable_file(shadow_filepath) as inf:
         for line in inf:
             if heartbeat.search(line) is not None:


### PR DESCRIPTION
Previously we would search the log file for the string "_manager_heartbeat", but now we search for "[Pp]rocess resource usage at simtime" instead.

From the "Run all steps" CI test output, the "resource_usage.json" file shows data for the "run_time" field, so I think this code is still working correctly.