### PR TITLE
Add new shadow 3.0 tgentools/oniontracetools search strings

### DIFF
--- a/.github/workflows/run_all_steps.yml
+++ b/.github/workflows/run_all_steps.yml
@@ -16,7 +16,7 @@ on:
 
 env:
   DEBIAN_FRONTEND: noninteractive
-  SHADOW_COMMIT: v2.4.0
+  SHADOW_COMMIT: 1ad00720f6c1a8eec8fbdb65af560faa223b2b14
   TOR_REPO: https://git.torproject.org/tor.git
   TOR_BRANCH: release-0.4.6
   TOR_COMMIT: f728e09ebe611d6858e721eaa37637025bfbf259

--- a/.github/workflows/run_all_steps.yml
+++ b/.github/workflows/run_all_steps.yml
@@ -18,11 +18,11 @@ env:
   DEBIAN_FRONTEND: noninteractive
   SHADOW_COMMIT: 1ad00720f6c1a8eec8fbdb65af560faa223b2b14
   TOR_REPO: https://git.torproject.org/tor.git
-  TOR_BRANCH: release-0.4.6
+  TOR_BRANCH: release-0.4.7
   TOR_COMMIT: f728e09ebe611d6858e721eaa37637025bfbf259
   # Optimization - this must be older than $TOR_COMMIT, but ideally not much
   # older.
-  TOR_SHALLOW_SINCE: '2021-08-01'
+  TOR_SHALLOW_SINCE: '2023-01-01'
   TGEN_COMMIT: 3d7788bad362b4487d1145da93ab2fdb73c9b639
   ONIONTRACE_COMMIT: 9e0e83ceb0765bc915a2888bcc02e68a5a9b848f
   NETDATA_MONTH: '2020-11'

--- a/.github/workflows/run_all_steps.yml
+++ b/.github/workflows/run_all_steps.yml
@@ -23,8 +23,8 @@ env:
   # Optimization - this must be older than $TOR_COMMIT, but ideally not much
   # older.
   TOR_SHALLOW_SINCE: '2021-08-01'
-  TGEN_COMMIT: 8cec86f46c8ca719ff9c023e381363098b99586d
-  ONIONTRACE_COMMIT: bc26be3c4737a8a367a156f12bab2975cd811855
+  TGEN_COMMIT: 3d7788bad362b4487d1145da93ab2fdb73c9b639
+  ONIONTRACE_COMMIT: 9e0e83ceb0765bc915a2888bcc02e68a5a9b848f
   NETDATA_MONTH: '2020-11'
   NETDATA_LAST_DAY: '30'
   # Increment to invalidate caches

--- a/tornettools/parse_oniontrace.py
+++ b/tornettools/parse_oniontrace.py
@@ -15,11 +15,13 @@ def parse_oniontrace_logs(args):
         return
 
     # oniontracetools supports a list of expressions that are used to search for oniontrace log filenames
-    # the first -e expression matches the log file names for Shadow v2.x.x
-    # and the second -e expression matches the log file names for Shadow v1.x.x
+    # the first -e expression matches the log file names for Shadow v3.x.x
+    # the second -e expression matches the log file names for Shadow v2.x.x
+    # and the third -e expression matches the log file names for Shadow v1.x.x
     cmd = [otracetools_exe,
            'parse',
            '-m', str(args.nprocesses),
+           '-e', r'/oniontrace\.[0-9]+\.stdout$',
            '-e', r'.*\.oniontrace\.[0-9]+\.stdout',
            '-e', r'stdout.*\.oniontrace\.[0-9]+\.log',
            'shadow.data/hosts']

--- a/tornettools/parse_tgen.py
+++ b/tornettools/parse_tgen.py
@@ -15,11 +15,13 @@ def parse_tgen_logs(args):
         return
 
     # tgentools supports a list of expressions that are used to search for oniontrace log filenames
-    # the first -e expression matches the log file names for Shadow v2.x.x
-    # and the second -e expression matches the log file names for Shadow v1.x.x
+    # the first -e expression matches the log file names for Shadow v3.x.x
+    # the second -e expression matches the log file names for Shadow v2.x.x
+    # and the third -e expression matches the log file names for Shadow v1.x.x
     cmd = [tgentools_exe,
            'parse',
            '-m', str(args.nprocesses),
+           '-e', r'perfclient[0-9]+(exit|onionservice)?/tgen\.[0-9]+\.stdout$',
            '-e', r'perfclient[0-9]+(exit|onionservice)?\.tgen\.[0-9]+\.stdout',
            '-e', r'stdout\.*perfclient[0-9]+\.tgen\.[0-9]+\.log',
            '--complete',


### PR DESCRIPTION
Shadow 3.0 will use [slightly different stdout filenames](https://github.com/shadow/shadow/pull/2833), which causes these files not to be found by tgentools and oniontracetools.

~This PR needs updated versions of tgen and oniontrace in the workflow, but they need to be merged first.~

I've tested this locally and it *seems* to correctly identify the correct files.