### PR TITLE
Improve line styles in plotting code

### DIFF
--- a/tornettools/plot_common.py
+++ b/tornettools/plot_common.py
@@ -11,7 +11,7 @@ mp_use('Agg') # for systems without X11
 
 
 DEFAULT_COLORS = ['C0', 'C1', 'C2', 'C3', 'C4', 'C5', 'C6', 'C7', 'C8', 'C9', 'C10', 'C11']
-DEFAULT_LINESTYLES = ['-', '--', ':', '-.']
+DEFAULT_LINESTYLES = ['-', '--', '-.', ':']
 
 class TailLog(mscale.ScaleBase):
     name = 'taillog'


### PR DESCRIPTION
Lines with style ':' should be drawn above lines with '-.', otherwise the ':' lines will be hidden by the '-.' lines.