### PR TITLE
Bump tor commit

### DIFF
--- a/.github/workflows/run_all_steps.yml
+++ b/.github/workflows/run_all_steps.yml
@@ -19,7 +19,7 @@ env:
   SHADOW_COMMIT: 1ad00720f6c1a8eec8fbdb65af560faa223b2b14
   TOR_REPO: https://git.torproject.org/tor.git
   TOR_BRANCH: release-0.4.7
-  TOR_COMMIT: f728e09ebe611d6858e721eaa37637025bfbf259
+  TOR_COMMIT: tor-0.4.7.13
   # Optimization - this must be older than $TOR_COMMIT, but ideally not much
   # older.
   TOR_SHALLOW_SINCE: '2023-01-01'


### PR DESCRIPTION
A previous commit changed the branch, but not the commit hash, so we were still testing an older version of tor.