### PR TITLE
Set consensus bandwidth weight to 20 for authorities (instead of 1)

### DIFF
--- a/tornettools/generate_tor.py
+++ b/tornettools/generate_tor.py
@@ -200,7 +200,7 @@ def __generate_tor_v3bw_file(args, authorities, relays):
 
         for (fp, authority) in sorted(authorities.items(), key=lambda kv: kv[1]['nickname']):
             # authorities are weighted minimially for regular circuits
-            cons_bw_weight = int(round(1.0))
+            cons_bw_weight = int(round(20.0))
             nickname = authority['nickname']
             tornet_fp = authority['tornet_fingerprint']
             v3bwfile.write("node_id=${}\tbw={}\tnick={}\n".format(tornet_fp, cons_bw_weight, nickname))


### PR DESCRIPTION
Change the consensus bandwidth weight for the authorities generated by the tool to match the current situation.

Previously, generated authorities had `w Bandwidth=1` in the micro descriptors, they now have `w Bandwidth=20`.  This is consistent with the real network (e.g. [dannenberg](https://metrics.torproject.org/rs.html#details/7BE683E65D48141321C5ED92F075C55364AC7123) (authority) and all other authorities have a Consensus Weight of 20).