### PR TITLE
more robust parsing of user counts

### DIFF
--- a/tornettools/stage.py
+++ b/tornettools/stage.py
@@ -60,6 +60,8 @@ def stage_users(args, min_unix_time, max_unix_time):
 
             date = str(parts[0]) # like '2019-01-01'
             country_code = str(parts[1]) # like 'us'
+            # At least one float has been observed in the file:
+            # <https://gitlab.torproject.org/tpo/network-health/metrics/website/-/issues/40121>
             user_count = int(float(parts[2])) # like '14714' or '2e+05'
 
             dt = datetime.strptime(date, "%Y-%m-%d").replace(tzinfo=timezone.utc)

--- a/tornettools/stage.py
+++ b/tornettools/stage.py
@@ -60,7 +60,7 @@ def stage_users(args, min_unix_time, max_unix_time):
 
             date = str(parts[0]) # like '2019-01-01'
             country_code = str(parts[1]) # like 'us'
-            user_count = int(parts[2]) # like '14714'
+            user_count = int(float(parts[2])) # like '14714' or '2e+05'
 
             dt = datetime.strptime(date, "%Y-%m-%d").replace(tzinfo=timezone.utc)
             unix_time = int(dt.strftime("%s")) # returns stamp like 1548910800


### PR DESCRIPTION
The current [userstats-relay-country.csv](https://metrics.torproject.org/userstats-relay-country.csv) has the row `2024-08-21,de,2e+05,160074,263639,74`, which causes this line to choke on the `2e+05`. Arguably this should be fixed upstream (presumably there's a script generating this somewhere that never encountered a large round number of users before), but since we're never going to see anonymized usage metrics that lose anything from floating point precision, this fix is fine too.